### PR TITLE
Support TLS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ The exporter uses exclusively [MaxScale REST API](https://mariadb.com/kb/en/maxs
 
 We have prepared a Docker-compose file for a local try. Upon start, you get running MySQL, MaxScale and Exporter containers. Note that the Exported does not use command line arguments rather relies on environment variables:
 
-- MAXSCALE_ADDRESS. URL of MaxScale server, default is 127.0.0.1
-- MAXSCALE_PORT. Exposed MaxScale server port, default is 8989
+- MAXSCALE_URL. URL of MaxScale server, default is http://127.0.0.1:8989
 - MAXSCALE_USERNAME. MaxScale user name for connection to underlying MySQL database
 - MAXSCALE_PASSWORD. MaxScale user password for connection to underlying MySQL database
+- MAXSCALE_CA_CERTIFICATE. Certificate to use to verify a secure connection
 - MAXSCALE_EXPORTER_PORT. Port that the Exporter expose to provide metrics for Prometheus
 
 ### Run

--- a/maxscale_docker/docker-compose.yml
+++ b/maxscale_docker/docker-compose.yml
@@ -36,8 +36,7 @@ services:
     depends_on:
       - proxy
     environment:
-      MAXSCALE_ADDRESS: proxy
-      MAXSCALE_PORT: 8989
+      MAXSCALE_URL: http://proxy:8989
       MAXSCALE_USERNAME: admin
       MAXSCALE_PASSWORD: mariadb
       MAXSCALE_EXPORTER_PORT: 8093


### PR DESCRIPTION
This removes `MAXSCALE_ADDRESS` and `MAXSCALE_PORT` in favor of `MAXSCALE_URL` so that the schema can be configured, and adds a new `MAXSCALE_CA_CERTIFICATE` environment variable.

This fixes https://github.com/Vetal1977/maxctrl_exporter/issues/6